### PR TITLE
Restore focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 2.3.1
+## 2.4.0
 
 - Restore focus to the element that had it, after the modal has closed
+- REVERT `keydown` change in 2.3.0.
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+
+- Restore focus to the element that had it, after the modal has closed
+
 ## 2.3.0
 
 - Upgrade dependencies

--- a/addon/components/modal-dialog/index.hbs
+++ b/addon/components/modal-dialog/index.hbs
@@ -16,7 +16,6 @@
   {{did-insert this.handleInsertElement}}
   {{will-destroy this.handleDestroyElement}}
   {{on "click" this.handleClick}}
-  {{on "keyup" this.handleKeyUp}}
   {{on "keydown" this.handleKeyDown}}
 >
   <div class="modal-dialog__box" {{did-insert this.handleInsertBoxElement}}>

--- a/addon/components/modal-dialog/index.js
+++ b/addon/components/modal-dialog/index.js
@@ -73,15 +73,10 @@ export default class ModalDialogComponent extends Component {
 
   @action
   handleKeyDown(e) {
-    if (this._pressedTab(e)) {
-      this._trapFocus(e);
-    }
-  }
-
-  @action
-  handleKeyUp(e) {
     if (this._pressedEscape(e)) {
       this._attemptEscape();
+    } else if (this._pressedTab(e)) {
+      this._trapFocus(e);
     }
   }
 

--- a/addon/components/modal-dialog/index.js
+++ b/addon/components/modal-dialog/index.js
@@ -227,7 +227,6 @@ export default class ModalDialogComponent extends Component {
 
   _restoreFocus() {
     try {
-      console.log('restore', this.activeElement);
       this.activeElement.focus();
     } catch (error) {
       // Squelch

--- a/addon/components/modal-dialog/index.js
+++ b/addon/components/modal-dialog/index.js
@@ -25,6 +25,7 @@ export default class ModalDialogComponent extends Component {
     super(...arguments);
     this.rootElement = document.querySelector(':root');
     this.documentElement = document.documentElement;
+    this.activeElement = document.activeElement;
     this._load();
   }
 
@@ -57,7 +58,10 @@ export default class ModalDialogComponent extends Component {
 
   @action
   close() {
-    return this._hide().then(() => this.args.onClose?.());
+    return this._hide().then(() => {
+      this._restoreFocus();
+      this.args.onClose?.();
+    });
   }
 
   @action
@@ -218,6 +222,15 @@ export default class ModalDialogComponent extends Component {
     } else if (this._tabbedToEnd(e)) {
       this.firstFocusableElement.focus();
       e.preventDefault();
+    }
+  }
+
+  _restoreFocus() {
+    try {
+      console.log('restore', this.activeElement);
+      this.activeElement.focus();
+    } catch (error) {
+      // Squelch
     }
   }
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,7 +1,3 @@
-:focus {
-  border: 5px solid red;
-}
-
 @keyframes warn {
   0% {
     transform: scale(1);
@@ -42,6 +38,11 @@
   --modal-box-border-colour: grey;
   --modal-box-padding: 15px;
   --modal-ani-speed: 300ms;
+  --focus-outline-colour: red;
+}
+
+:focus {
+  outline: 2px solid var(--focus-outline-colour);
 }
 
 .modal-dialog {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,3 +1,7 @@
+:focus {
+  border: 5px solid red;
+}
+
 @keyframes warn {
   0% {
     transform: scale(1);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -45,6 +45,10 @@
   </p>
 
   <p>
+    When closing the modal, focus will be restored to the element that was originally focused.
+  </p>
+
+  <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut est eget nulla malesuada pretium id eu ipsum. Nam eu turpis et quam rutrum molestie a vitae tortor. Maecenas nec ex est. Nulla quis leo id leo commodo sagittis. Nullam diam dolor, semper sed convallis ut, facilisis sollicitudin quam. Ut a fermentum turpis, ac gravida elit. Fusce sed leo mollis nibh tincidunt ornare. Quisque convallis sodales erat, eget ultricies nulla pellentesque ut. Curabitur nec sem lorem.
   </p>
 

--- a/tests/integration/components/modal-dialog-test.js
+++ b/tests/integration/components/modal-dialog-test.js
@@ -25,7 +25,7 @@ module('modal-dialog', function (hooks) {
 
   module('rendering', function () {
     test('it works', async function (assert) {
-      assert.expect(10);
+      assert.expect(9);
 
       await render(hbs`
         <ModalDialog as |modal|>
@@ -50,10 +50,6 @@ module('modal-dialog', function (hooks) {
       assert.dom('.modal-dialog').hasAttribute('role', 'dialog');
 
       assert.dom('.modal-dialog').hasAttribute('aria-modal', 'true');
-
-      assert
-        .dom('.modal-dialog')
-        .isFocused('is focused to respond the keyboard');
 
       assert.dom('.modal-dialog__header').exists('can render the header');
 
@@ -96,6 +92,46 @@ module('modal-dialog', function (hooks) {
           'has-modal',
           'root element is informed when a modal dialog is present'
         );
+    });
+
+    test('focus', async function (assert) {
+      assert.expect(4);
+
+      await render(hbs`
+        <button type="button" class="external"></button>
+
+        {{#if this.showModal}}
+          <ModalDialog as |modal|>
+            <button type="button" class="internal" {{on "click" modal.close}}></button>
+          </ModalDialog>
+        {{/if}}
+      `);
+
+      await focus('.external');
+
+      assert
+        .dom('.external')
+        .isFocused('initial focus is on an element outside the modal');
+
+      this.set('showModal', true);
+
+      assert
+        .dom('.modal-dialog')
+        .isFocused('modal is focused to respond the keyboard');
+
+      await click('.internal');
+
+      assert
+        .dom('.internal')
+        .isFocused(
+          "focus isn't restored until after the animation (full closure)"
+        );
+
+      await waitForAnimation('.modal-dialog');
+
+      assert
+        .dom('.external')
+        .isFocused('focus is returned to the originally focused element');
     });
   });
 

--- a/tests/integration/components/modal-dialog-test.js
+++ b/tests/integration/components/modal-dialog-test.js
@@ -308,7 +308,7 @@ module('modal-dialog', function (hooks) {
           @onClose={{this.close}} />
       `);
 
-      await triggerKeyEvent('.modal-dialog', 'keyup', 27); // Escape
+      await triggerKeyEvent('.modal-dialog', 'keydown', 27); // Escape
 
       await waitForAnimation('.modal-dialog');
 
@@ -327,7 +327,7 @@ module('modal-dialog', function (hooks) {
         <ModalDialog @onClose={{this.close}} />
       `);
 
-      await triggerKeyEvent('.modal-dialog', 'keyup', 27); // Escape
+      await triggerKeyEvent('.modal-dialog', 'keydown', 27); // Escape
 
       assert
         .dom('.modal-dialog')


### PR DESCRIPTION
When the modal dialog is closed, restore focus to whatever element had it before it was opened