### PR TITLE
Properly remove event listener

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -105,7 +105,7 @@ export default class ModalDialogComponent extends Component {
 
     return () => {
       observer.disconnect();
-      window.addEventListener('resize', handler);
+      window.removeEventListener('resize', handler);
     };
   });
 


### PR DESCRIPTION
In the tear-down callback there was an obvious issue: the 'resize'
event listener should've been removed, while it was actaully readded.